### PR TITLE
feat: add host config support for remote Electron debugging and HTTP server bind address

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -122,7 +122,7 @@ export async function handleToolCall(request: CallToolRequest) {
         const host = resolveHost(projectName);
 
         // Build window target options if specified
-        const windowOptions: WindowTargetOptions | undefined =
+        const windowOptions: WindowTargetOptions =
           targetId || windowTitle || ports ? { targetId, windowTitle, ports, host } : { host };
 
         const result = await sendCommandToElectron(command, commandArgs, windowOptions);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -12,7 +12,11 @@ import {
   ListProjectsSchema,
 } from './schemas';
 import { sendCommandToElectron } from './utils/electron-enhanced-commands';
-import { getElectronWindowInfo, listElectronWindows, scanForElectronApps } from './utils/electron-discovery';
+import {
+  getElectronWindowInfo,
+  listElectronWindows,
+  scanForElectronApps,
+} from './utils/electron-discovery';
 import { WindowTargetOptions } from './utils/electron-connection';
 import { readElectronLogs } from './utils/electron-logs';
 import { takeScreenshot } from './screenshot';
@@ -24,6 +28,17 @@ let defaultProjectName: string | undefined;
 
 export function setDefaultProject(name: string | undefined) {
   defaultProjectName = name;
+}
+
+function resolveHost(projectName?: string): string {
+  const effectiveName = projectName || defaultProjectName;
+  if (effectiveName) {
+    const config = projectRegistry.resolve(effectiveName);
+    if (config?.host) {
+      return config.host;
+    }
+  }
+  return projectRegistry.getHost();
 }
 
 /**
@@ -51,7 +66,8 @@ export async function handleToolCall(request: CallToolRequest) {
       case ToolName.GET_ELECTRON_WINDOW_INFO: {
         const { includeChildren, projectName } = GetElectronWindowInfoSchema.parse(args);
         const ports = resolveProjectPorts(projectName);
-        const result = await getElectronWindowInfo(includeChildren, ports);
+        const host = resolveHost(projectName);
+        const result = await getElectronWindowInfo(includeChildren, ports, host);
         return {
           content: [
             {
@@ -66,7 +82,8 @@ export async function handleToolCall(request: CallToolRequest) {
       case ToolName.TAKE_SCREENSHOT: {
         const { outputPath, targetId, windowTitle, projectName } = TakeScreenshotSchema.parse(args);
         const ports = resolveProjectPorts(projectName);
-        const result = await takeScreenshot({ outputPath, targetId, windowTitle, ports });
+        const host = resolveHost(projectName);
+        const result = await takeScreenshot({ outputPath, targetId, windowTitle, ports, host });
 
         const content: any[] = [];
 
@@ -102,12 +119,11 @@ export async function handleToolCall(request: CallToolRequest) {
         } = SendCommandToElectronSchema.parse(args);
 
         const ports = resolveProjectPorts(projectName);
+        const host = resolveHost(projectName);
 
         // Build window target options if specified
         const windowOptions: WindowTargetOptions | undefined =
-          targetId || windowTitle || ports
-            ? { targetId, windowTitle, ports }
-            : undefined;
+          targetId || windowTitle || ports ? { targetId, windowTitle, ports, host } : { host };
 
         const result = await sendCommandToElectron(command, commandArgs, windowOptions);
         return {
@@ -119,7 +135,8 @@ export async function handleToolCall(request: CallToolRequest) {
       case ToolName.READ_ELECTRON_LOGS: {
         const { logType, lines, follow, projectName } = ReadElectronLogsSchema.parse(args);
         const ports = resolveProjectPorts(projectName);
-        const logs = await readElectronLogs(logType, lines, follow, ports);
+        const host = resolveHost(projectName);
+        const logs = await readElectronLogs(logType, lines, follow, ports, host);
 
         if (follow) {
           return {
@@ -147,7 +164,8 @@ export async function handleToolCall(request: CallToolRequest) {
       case ToolName.LIST_ELECTRON_WINDOWS: {
         const { includeDevTools, projectName } = ListElectronWindowsSchema.parse(args);
         const ports = resolveProjectPorts(projectName);
-        const windows = await listElectronWindows(includeDevTools, ports);
+        const host = resolveHost(projectName);
+        const windows = await listElectronWindows(includeDevTools, ports, host);
 
         if (windows.length === 0) {
           return {
@@ -179,13 +197,14 @@ export async function handleToolCall(request: CallToolRequest) {
       }
 
       case ToolName.REGISTER_PROJECT: {
-        const { projectName, port, windowTitlePattern } = RegisterProjectSchema.parse(args);
-        const config = projectRegistry.register(projectName, port, windowTitlePattern);
+        const { projectName, port, host, windowTitlePattern } = RegisterProjectSchema.parse(args);
+        const config = projectRegistry.register(projectName, port, windowTitlePattern, host);
 
         // Check if the port is currently reachable
         let statusNote = '';
         try {
-          const apps = await scanForElectronApps([config.port]);
+          const host = config.host || projectRegistry.getHost();
+          const apps = await scanForElectronApps([config.port], host);
           if (apps.length > 0) {
             statusNote = `\n\nNote: An Electron app is already running on port ${config.port} with ${apps[0].targets.length} window(s).`;
           }
@@ -198,6 +217,8 @@ export async function handleToolCall(request: CallToolRequest) {
             {
               type: 'text',
               text: `Project "${projectName}" registered on port ${config.port}.${
+                config.host ? ` Host: ${config.host}.` : ''
+              }${
                 config.windowTitlePattern
                   ? ` Window title filter: "${config.windowTitlePattern}".`
                   : ''
@@ -257,7 +278,8 @@ export async function handleToolCall(request: CallToolRequest) {
         for (const [name, config] of entries) {
           let status = 'not connected';
           try {
-            const apps = await scanForElectronApps([config.port]);
+            const host = config.host || projectRegistry.getHost();
+            const apps = await scanForElectronApps([config.port], host);
             if (apps.length > 0) {
               status = `connected (${apps[0].targets.length} window(s))`;
             }
@@ -268,7 +290,7 @@ export async function handleToolCall(request: CallToolRequest) {
           lines.push(
             `- ${name}: port ${config.port} [${status}]${
               config.windowTitlePattern ? ` (filter: "${config.windowTitlePattern}")` : ''
-            }`,
+            }${config.host ? ` (host: ${config.host})` : ''}`,
           );
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ function parseArgs(argv: string[]) {
   let project: string | undefined;
   let mode: 'stdio' | 'serve' = 'stdio';
   let httpPort = 3100;
+  let httpHost = '0.0.0.0';
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === 'serve') {
@@ -21,10 +22,12 @@ function parseArgs(argv: string[]) {
       project = args[++i];
     } else if (args[i] === '--port' && i + 1 < args.length) {
       httpPort = parseInt(args[++i], 10);
+    } else if (args[i] === '--host' && i + 1 < args.length) {
+      httpHost = args[++i];
     }
   }
 
-  return { project, mode, httpPort };
+  return { project, mode, httpPort, httpHost };
 }
 
 /**
@@ -74,11 +77,11 @@ function ensureProjectRegistered(name: string): { name: string; port: number; is
   return { name, port: config.port, isNew: true };
 }
 
-const { project, mode, httpPort } = parseArgs(process.argv);
+const { project, mode, httpPort, httpHost } = parseArgs(process.argv);
 
 if (mode === 'serve') {
   import('./serve').then(({ startHttpServer }) => {
-    startHttpServer(httpPort).catch((error) => {
+    startHttpServer(httpPort, httpHost).catch((error) => {
       logger.error('HTTP server error:', error);
       process.exit(1);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function parseArgs(argv: string[]) {
   let project: string | undefined;
   let mode: 'stdio' | 'serve' = 'stdio';
   let httpPort = 3100;
-  let httpHost = '0.0.0.0';
+  let httpHost = '127.0.0.1';
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === 'serve') {

--- a/src/project-registry.ts
+++ b/src/project-registry.ts
@@ -5,10 +5,12 @@ import { logger } from './utils/logger';
 
 export interface ProjectConfig {
   port: number;
+  host?: string;
   windowTitlePattern?: string;
 }
 
 export interface RegistryConfig {
+  host?: string;
   portRange: [number, number];
   projects: Record<string, ProjectConfig>;
 }
@@ -30,6 +32,10 @@ class ProjectRegistry {
     this.load();
   }
 
+  getHost(): string {
+    return this.config.host || 'localhost';
+  }
+
   static getInstance(): ProjectRegistry {
     if (!ProjectRegistry.instance) {
       ProjectRegistry.instance = new ProjectRegistry();
@@ -37,12 +43,18 @@ class ProjectRegistry {
     return ProjectRegistry.instance;
   }
 
-  register(name: string, port?: number, windowTitlePattern?: string): ProjectConfig {
+  register(name: string, port?: number, windowTitlePattern?: string, host?: string): ProjectConfig {
     if (this.config.projects[name]) {
       const existing = this.config.projects[name];
       // Update windowTitlePattern if provided
       if (windowTitlePattern !== undefined) {
         existing.windowTitlePattern = windowTitlePattern;
+      }
+      // Update host if provided
+      if (host !== undefined) {
+        existing.host = host;
+      }
+      if (windowTitlePattern !== undefined || host !== undefined) {
         this.save();
       }
       return existing;
@@ -52,6 +64,9 @@ class ProjectRegistry {
     const projectConfig: ProjectConfig = { port: assignedPort };
     if (windowTitlePattern) {
       projectConfig.windowTitlePattern = windowTitlePattern;
+    }
+    if (host) {
+      projectConfig.host = host;
     }
 
     this.config.projects[name] = projectConfig;
@@ -105,6 +120,9 @@ class ProjectRegistry {
       if (fs.existsSync(this.configPath)) {
         const data = fs.readFileSync(this.configPath, 'utf-8');
         const parsed = JSON.parse(data);
+        if (parsed.host !== undefined) {
+          this.config.host = parsed.host;
+        }
         if (parsed.portRange) {
           this.config.portRange = parsed.portRange;
         }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -62,11 +62,15 @@ export const TakeScreenshotSchema = z.object({
   targetId: z
     .string()
     .optional()
-    .describe('CDP target ID to screenshot a specific window (exact match, takes priority over windowTitle)'),
+    .describe(
+      'CDP target ID to screenshot a specific window (exact match, takes priority over windowTitle)',
+    ),
   windowTitle: z
     .string()
     .optional()
-    .describe('Window title to screenshot (case-insensitive partial match). Use list_electron_windows to see available windows.'),
+    .describe(
+      'Window title to screenshot (case-insensitive partial match). Use list_electron_windows to see available windows.',
+    ),
   projectName: z
     .string()
     .optional()
@@ -120,6 +124,10 @@ export const RegisterProjectSchema = z.object({
     .number()
     .optional()
     .describe('Explicit port number (auto-assigned from range if omitted)'),
+  host: z
+    .string()
+    .optional()
+    .describe('Host IP to connect to (e.g., Windows IP when debugging from WSL)'),
   windowTitlePattern: z
     .string()
     .optional()

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -14,31 +14,33 @@ export interface ScreenshotOptions {
   windowTitle?: string;
   /** Specific ports to scan (overrides default port scanning) */
   ports?: number[];
+  /** Host to connect to (defaults to 'localhost') */
+  host?: string;
 }
 
 /**
  * Take a screenshot of the running Electron application using Chrome DevTools Protocol
  */
-export async function takeScreenshot(
-  options: ScreenshotOptions = {},
-): Promise<{
+export async function takeScreenshot(options: ScreenshotOptions = {}): Promise<{
   filePath?: string;
   base64: string;
   data: string;
   error?: string;
 }> {
-  const { outputPath, targetId, windowTitle, ports } = options;
+  const { outputPath, targetId, windowTitle, ports, host } = options;
+  const effectiveHost = host || 'localhost';
 
   logger.info('📸 Taking screenshot of Electron application', {
     outputPath,
     targetId,
     windowTitle,
+    host: effectiveHost,
     timestamp: new Date().toISOString(),
   });
 
   try {
     // Find running Electron applications
-    const apps = await scanForElectronApps(ports);
+    const apps = await scanForElectronApps(ports, effectiveHost);
     if (apps.length === 0) {
       throw new Error('No running Electron applications found with remote debugging enabled');
     }
@@ -86,7 +88,7 @@ export async function takeScreenshot(
     }
 
     // Connect to the Electron app's debugging port
-    const browser = await chromium.connectOverCDP(`http://localhost:${targetApp.port}`);
+    const browser = await chromium.connectOverCDP(`http://${effectiveHost}:${targetApp.port}`);
     const contexts = browser.contexts();
 
     if (contexts.length === 0) {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -31,7 +31,7 @@ function sendJson(res: ServerResponse, status: number, data: unknown) {
  * Uses only Node built-in http — no express or other dependencies.
  * Supports multiple concurrent AI client sessions.
  */
-export async function startHttpServer(port: number = 3100, host: string = '0.0.0.0'): Promise<void> {
+export async function startHttpServer(port: number = 3100, host: string = '127.0.0.1'): Promise<void> {
   // Map of session ID -> transport
   const transports: Record<string, StreamableHTTPServerTransport> = {};
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -31,7 +31,7 @@ function sendJson(res: ServerResponse, status: number, data: unknown) {
  * Uses only Node built-in http — no express or other dependencies.
  * Supports multiple concurrent AI client sessions.
  */
-export async function startHttpServer(port: number = 3100): Promise<void> {
+export async function startHttpServer(port: number = 3100, host: string = '0.0.0.0'): Promise<void> {
   // Map of session ID -> transport
   const transports: Record<string, StreamableHTTPServerTransport> = {};
 
@@ -130,8 +130,8 @@ export async function startHttpServer(port: number = 3100): Promise<void> {
     }
   });
 
-  server.listen(port, '127.0.0.1', () => {
-    logger.info(`Electron MCP HTTP Server listening on http://127.0.0.1:${port}`);
+  server.listen(port, host, () => {
+    logger.info(`Electron MCP HTTP Server listening on http://${host}:${port}`);
     logger.info(`MCP endpoint: http://localhost:${port}/mcp`);
     logger.info(`Health check: http://localhost:${port}/health`);
     logger.info('Available tools:', tools.map((t) => t.name).join(', '));

--- a/src/utils/electron-connection.ts
+++ b/src/utils/electron-connection.ts
@@ -25,6 +25,8 @@ export interface WindowTargetOptions {
   windowTitle?: string;
   /** Specific ports to scan (overrides default port scanning) */
   ports?: number[];
+  /** Host to connect to (defaults to 'localhost') */
+  host?: string;
 }
 
 /**
@@ -39,7 +41,7 @@ export interface WindowTargetOptions {
 export async function findElectronTarget(options?: WindowTargetOptions): Promise<DevToolsTarget> {
   logger.debug('Looking for running Electron applications...');
 
-  const foundApps = await scanForElectronApps(options?.ports);
+  const foundApps = await scanForElectronApps(options?.ports, options?.host);
 
   if (foundApps.length === 0) {
     throw new Error(

--- a/src/utils/electron-discovery.ts
+++ b/src/utils/electron-discovery.ts
@@ -40,21 +40,44 @@ export interface ElectronWindowResult {
  * Scan for running Electron applications with DevTools enabled
  * @param ports - Optional list of specific ports to scan. When provided, only these ports are checked.
  *                When omitted, scans the default hardcoded port ranges.
+ * @param host - Optional host to connect to. Defaults to 'localhost'.
  */
-export async function scanForElectronApps(ports?: number[]): Promise<ElectronAppInfo[]> {
-  logger.debug('Scanning for running Electron applications...');
+export async function scanForElectronApps(
+  ports?: number[],
+  host?: string,
+): Promise<ElectronAppInfo[]> {
+  const effectiveHost = host || 'localhost';
+  logger.debug(`Scanning for running Electron applications on ${effectiveHost}...`);
 
   const portsToScan = ports ?? [
-    9222, 9223, 9224, 9225, // Default ports
-    9200, 9201, 9202, 9203, 9204, 9205, // Security test range
-    9300, 9301, 9302, 9303, 9304, 9305, // Integration test range
-    9400, 9401, 9402, 9403, 9404, 9405, // Additional range
+    9222,
+    9223,
+    9224,
+    9225, // Default ports
+    9200,
+    9201,
+    9202,
+    9203,
+    9204,
+    9205, // Security test range
+    9300,
+    9301,
+    9302,
+    9303,
+    9304,
+    9305, // Integration test range
+    9400,
+    9401,
+    9402,
+    9403,
+    9404,
+    9405, // Additional range
   ];
   const foundApps: ElectronAppInfo[] = [];
 
   for (const port of portsToScan) {
     try {
-      const response = await fetch(`http://localhost:${port}/json`, {
+      const response = await fetch(`http://${effectiveHost}:${port}/json`, {
         signal: AbortSignal.timeout(1000),
       });
 
@@ -124,13 +147,15 @@ export function findMainTarget(targets: any[]): any | null {
  * List all available Electron window targets across all detected apps.
  * @param includeDevTools - Whether to include DevTools windows (default: false)
  * @param ports - Optional list of specific ports to scan
+ * @param host - Optional host to connect to. Defaults to 'localhost'.
  * @returns Array of window targets with id, title, url, port, and type
  */
 export async function listElectronWindows(
   includeDevTools: boolean = false,
   ports?: number[],
+  host?: string,
 ): Promise<ElectronWindowTarget[]> {
-  const foundApps = await scanForElectronApps(ports);
+  const foundApps = await scanForElectronApps(ports, host);
   const windows: ElectronWindowTarget[] = [];
 
   for (const app of foundApps) {
@@ -156,13 +181,15 @@ export async function listElectronWindows(
  * Get window information from any running Electron app
  * @param includeChildren - Whether to include child/DevTools windows
  * @param ports - Optional list of specific ports to scan
+ * @param host - Optional host to connect to. Defaults to 'localhost'.
  */
 export async function getElectronWindowInfo(
   includeChildren: boolean = false,
   ports?: number[],
+  host?: string,
 ): Promise<ElectronWindowResult> {
   try {
-    const foundApps = await scanForElectronApps(ports);
+    const foundApps = await scanForElectronApps(ports, host);
 
     if (foundApps.length === 0) {
       return {

--- a/src/utils/electron-logs.ts
+++ b/src/utils/electron-logs.ts
@@ -18,18 +18,21 @@ export interface LogEntry {
  * @param lines - Number of recent lines to read
  * @param follow - Whether to follow/tail the logs
  * @param ports - Optional list of specific ports to scan
+ * @param host - Optional host to connect to
  */
 export async function readElectronLogs(
   logType: LogType = 'all',
   lines: number = 100,
   follow: boolean = false,
   ports?: number[],
+  host?: string,
 ): Promise<string> {
   try {
     logger.info('[MCP] Looking for running Electron applications for log access...');
 
     try {
-      const windowOptions: WindowTargetOptions | undefined = ports ? { ports } : undefined;
+      const windowOptions: WindowTargetOptions | undefined =
+        ports || host ? { ports, host } : undefined;
       const target = await findElectronTarget(windowOptions);
 
       // Connect via WebSocket to get console logs


### PR DESCRIPTION
## Summary

- Add `host` config support for connecting to Electron apps running on remote hosts (e.g., debugging Windows Electron from WSL)
- Add `--host` CLI option for HTTP server to specify bind address

## Changes

### 1. Host config support for Electron debugging

Added `host` field to project registry config, allowing connection to Electron apps on remote IPs.

**Config file example (`~/.debug-electron-mcp.json`):**
```json
{
  "host": "172.x.x.x",
  "portRange": [11902, 11903],
  "projects": {
    "my-project": {
      "port": 11902,
      "host": "172.x.x.x"
    }
  }
}
```

- Global `host` as default for all projects
- Project-level `host` overrides global setting
- `register_project` tool now accepts `host` parameter

### 2. HTTP server `--host` option

Added `--host` flag to `serve` command for bind address control:

```bash
# Default: bind to all interfaces (0.0.0.0)
npx @debugelectron/debug-electron-mcp serve --port 4000

# Bind to localhost only
npx @debugelectron/debug-electron-mcp serve --port 4000 --host 127.0.0.1

# Bind to specific IP
npx @debugelectron/debug-electron-mcp serve --port 4000 --host 172.x.x.x
```

## Use Case

Debug Windows Electron application from WSL environment:
1. Electron runs on Windows with `--remote-debugging-port=9222`
2. MCP server runs in WSL
3. Configure `host` to Windows IP (obtained via `ipconfig` on Windows)
4. MCP tools can now connect to Windows Electron via network
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --host CLI option to configure the HTTP server bind address.
  * Projects can be registered with and display a specific host IP for remote connections.
  * Electron debugging, screenshots, window listing and log retrieval can target a specified host (supports cross-network scenarios like WSL).
  * Server listening URL now reflects the configured host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->